### PR TITLE
Deferred check

### DIFF
--- a/l10n_ar_account_check/account.py
+++ b/l10n_ar_account_check/account.py
@@ -2,6 +2,7 @@
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
+#    Copyright (C) 2008-2011  Thymbra
 #    Copyright (c) 2011-2014 E-MIPS (http://www.e-mips.com.ar)
 #    Copyright (c) 2014 Aconcagua Team (http://www.proyectoaconcagua.com.ar)
 #    All Rights Reserved. See AUTHORS for details.
@@ -21,8 +22,12 @@
 #
 ##############################################################################
 
-import account
-import account_check
-import account_voucher
-import res_partner_bank
-import wizard
+from openerp import models, fields, api
+from openerp.tools.translate import _
+
+
+class account_move_line(models.Model):
+    _name = 'account.move.line'
+    _inherit = 'account.move.line'
+
+    issued_check_id = fields.Many2one('account.issued.check', 'Issued Check')

--- a/l10n_ar_account_check/account_check.py
+++ b/l10n_ar_account_check/account_check.py
@@ -26,6 +26,7 @@ import time
 
 from openerp import _, api, exceptions, fields, models
 from openerp.osv import osv
+from openerp.exceptions import except_orm
 
 
 class account_check_config(models.Model):
@@ -47,6 +48,7 @@ class account_check_config(models.Model):
                                  help="In Argentina, Valores a Depositar is used, for example")
     deferred_account_id = fields.Many2one('account.account', 'Deferred Check Account',
                                           required=True)
+    deferred_journal_id = fields.Many2one('account.journal', 'Deferred Check Journal', required=True)
     company_id = fields.Many2one('res.company', 'Company', required=True)
 
     _sql_constraints = [
@@ -74,6 +76,8 @@ class account_issued_check(models.Model):
     clearing = fields.Selection([('24', '24 hs'), ('48', '48 hs'), ('72', '72 hs')], 'Clearing', default='24')
     account_bank_id = fields.Many2one('res.partner.bank', 'Bank Account')
     voucher_id = fields.Many2one('account.voucher', 'Voucher')
+    payment_move_id = fields.Many2one('account.move', 'Payment Account Move')
+    clearance_move_id = fields.Many2one('account.move', 'Clearance Account Move')
     origin = fields.Char('Origin', size=64)
     type = fields.Selection([('common', 'Common'), ('postdated', 'Post-dated')], 'Check Type', default='common', help="If common, checks only have issued_date. If post-dated they also have payment date")
     company_id = fields.Many2one('res.company', 'Company', required=True, readonly=True, default=lambda self: self.env.user.company_id.id)
@@ -158,13 +162,69 @@ class account_issued_check(models.Model):
                 raise osv.except_osv(_('Check Error'), _('You cannot delete an issued check that is not in Draft state [See %s].') % (check.voucher_id))
         return super(account_issued_check, self).unlink()
 
+    @api.multi
     def accredit_checks(self):
         #TODO: create the corresponding moves
         for check in self:
             if check.state != "waiting":
                 raise exceptions.ValidationError(_("Check %s can't be accredited!") % check.number)
 
+        for check in self:
+            company = self.env.user.company_id
+            check_conf_obj = self.env['account.check.config']
+            def_check_account = check_conf_obj.search([('company_id', '=', company.id)]).deferred_account_id
+            def_check_journal = check_conf_obj.search([('company_id', '=', company.id)]).deferred_journal_id
+            if not def_check_journal:
+                raise except_orm(_("Error!"),_("There is no Journal configured for deferred checks."))
+
+
+            current_date = time.strftime('%Y-%m-%d')
+
+            period_obj = self.env['account.period']
+            current_period = period_obj.search([('date_start', '<=', current_date), ('date_stop', '>=', current_date)])
+
+            move_line_obj = self.env['account.move.line']
+            move_obj = self.env['account.move']
+            name_ref = 'Clearance Check ' + check.number
+            move_vals = {   'ref': name_ref,
+                            'journal_id': def_check_journal.id,
+                        }
+            move_id = move_obj.create(move_vals)
+
+            check.write({'move_id': move_id.id})
+
+            check_move_line_vals = {    'journal_id': def_check_journal.id,
+                                        'period_id': current_period.id,
+                                        'date': current_date,
+                                        'name': name_ref,
+                                        'account_id': def_check_account.id,
+                                        'debit': check.amount,
+                                        'move_id': move_id.id,
+                                   }
+
+            clearance_move_line = move_line_obj.create(check_move_line_vals)
+
+            bank_move_line_vals = {     'journal_id': def_check_journal.id,
+                                        'period_id': current_period.id,
+                                        'date': current_date,
+                                        'name': name_ref,
+                                        'account_id': check.checkbook_id.bank_account_id.account_id.id,
+                                        'credit': check.amount,
+                                        'move_id': move_id.id,
+                                   }
+
+            move_line_obj.create(bank_move_line_vals)
+
+
+            move_lines_to_reconcile = []
+            payment_move_line = move_line_obj.search([('issued_check_id', '=', check.id)])
+            move_lines_to_reconcile.append(payment_move_line.id)
+            move_lines_to_reconcile.append(clearance_move_line.id)
+            reconcile_recordset = move_line_obj.browse(move_lines_to_reconcile)
+            reconcile_recordset.reconcile()
+
         return self.write({"state": "issued"})
+
 
     def accredit_checks_cron_task(self):
         """ Search postdated checks and accredit them. This method is meant to be used by a cron

--- a/l10n_ar_account_check/account_check_view.xml
+++ b/l10n_ar_account_check/account_check_view.xml
@@ -17,6 +17,7 @@
                     <field name="company_id"/>
                     <field name="account_id"/>
                     <field name="deferred_account_id"/>
+                    <field name="deferred_journal_id"/>
                 </tree>
             </field>
         </record>
@@ -35,6 +36,7 @@
                             <field name="company_id"/>
                             <field name="account_id"/>
                             <field name="deferred_account_id"/>
+                            <field name="deferred_journal_id"/>
                         </group>
                     </sheet>
                 </form>
@@ -84,6 +86,7 @@
             <field name="arch" type="xml">
                 <form string="Issued Checks" version="7.0">
                     <header>
+                        <button name="accredit_checks" string="Accredit Check" type="object" states="waiting" class="oe_highlight"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,issued" statusbar_colors='{"cancel":"red"}'/>
                     </header>
                     <sheet>
@@ -113,6 +116,8 @@
                             </group>
                             <group>
                                 <field name="origin"/>
+                                <field name="payment_move_id" readonly="1"/>
+                                <field name="clearance_move_id" readonly="1"/>
                             </group>
                          </group>
                     </sheet>

--- a/l10n_ar_account_check/account_check_view.xml
+++ b/l10n_ar_account_check/account_check_view.xml
@@ -87,6 +87,8 @@
                 <form string="Issued Checks" version="7.0">
                     <header>
                         <button name="accredit_checks" string="Accredit Check" type="object" states="waiting" class="oe_highlight"/>
+                        <button name="break_conciliation" string="Break Conciliation" type="object" class="oe_highlight"
+                            attrs="{'invisible': ['|', ('state', 'not in', ['issued']), ('accredited', '=', 'False')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,issued" statusbar_colors='{"cancel":"red"}'/>
                     </header>
                     <sheet>
@@ -118,6 +120,7 @@
                                 <field name="origin"/>
                                 <field name="payment_move_id" readonly="1"/>
                                 <field name="clearance_move_id" readonly="1"/>
+                                <field name="accredited" invisible="1"/>
                             </group>
                          </group>
                     </sheet>

--- a/l10n_ar_account_check/account_voucher.py
+++ b/l10n_ar_account_check/account_voucher.py
@@ -22,9 +22,10 @@
 #
 ##############################################################################
 
-from openerp import models, fields, api
+from openerp import models, fields, api, exceptions
 from openerp.tools.translate import _
 
+from openerp.exceptions import except_orm
 
 class account_voucher(models.Model):
     _name = 'account.voucher'
@@ -229,6 +230,11 @@ class account_voucher(models.Model):
 
             # Cancelamos los cheques emitidos
             issued_checks = voucher.issued_check_ids
+            for check in issued_checks:
+                if check.type == 'postdated' and check.accredited:
+                    err = _('Check number %s is postdated and has already been accredited!\nPlease break the conciliation of that check first.') % check.number
+                    raise exceptions.ValidationError(err)
+
             issued_checks.cancel_check()
 
         return res

--- a/l10n_ar_account_check/account_voucher.py
+++ b/l10n_ar_account_check/account_voucher.py
@@ -182,6 +182,7 @@ class account_voucher(models.Model):
 
                 res = check.create_voucher_move_line()
                 res['move_id'] = move_id
+                res['issued_check_id'] = check.id
                 move_lines.append(res)
 
                 if check.type == 'postdated':
@@ -189,7 +190,7 @@ class account_voucher(models.Model):
                 else:
                     state = 'issued'
 
-                vals = {'state': state, 'receiving_partner_id': self.partner_id.id}
+                vals = {'state': state, 'payment_move_id': move_id, 'receiving_partner_id': self.partner_id.id}
 
                 if not check.origin:
                     vals['origin'] = self.reference

--- a/l10n_ar_account_check/account_voucher_view.xml
+++ b/l10n_ar_account_check/account_voucher_view.xml
@@ -25,7 +25,7 @@
                             <form string="Issued Checks">
                                 <group>
                                     <group>
-                                        <field name="number"/>
+                                        <field name="number" invisible="1"/>
                                         <field name="type" readonly="1"/>
                                         <field name="amount"/>
                                         <field name="bank_id" invisible="1"/>

--- a/l10n_ar_account_check/account_voucher_view.xml
+++ b/l10n_ar_account_check/account_voucher_view.xml
@@ -28,7 +28,7 @@
                                         <field name="number"/>
                                         <field name="type" readonly="1"/>
                                         <field name="amount"/>
-                                        <field name="bank_id" readonly="1"/>
+                                        <field name="bank_id" invisible="1"/>
                                         <field name="company_id" invisible="0"/>
                                     </group>
                                     <group>

--- a/l10n_ar_account_check/account_voucher_view.xml
+++ b/l10n_ar_account_check/account_voucher_view.xml
@@ -26,16 +26,16 @@
                                 <group>
                                     <group>
                                         <field name="number"/>
-                                        <field name="type"/>
+                                        <field name="type" readonly="1"/>
                                         <field name="amount"/>
-                                        <field name="bank_id"/>
+                                        <field name="bank_id" readonly="1"/>
                                         <field name="company_id" invisible="0"/>
                                     </group>
                                     <group>
                                         <field name="issue_date"/>
                                         <field name="payment_date" attrs="{'invisible': [('type', '=', 'common')],
                                                                            'required': [('type', '=', 'postdated')]}"/>
-                                        <field name="account_bank_id" domain="[('company_id', '=', company_id)]" required="1"/>
+                                        <field name="account_bank_id" domain="[('company_id', '=', company_id)]" required="1" readonly="1"/>
                                         <field name="clearing"/>
                                         <field name="signatory"/>
                                         <field name="origin"/>

--- a/l10n_ar_account_create_check/checkbook.py
+++ b/l10n_ar_account_create_check/checkbook.py
@@ -173,7 +173,9 @@ class account_issued_check(models.Model):
         return ret
 
     def create(self, cr, uid, vals, context=None):
-        checkbook = vals.get('checkbook', False)
+        checkbook_id = vals.get('checkbook_id', False)
+        checkbook_obj = self.pool['account.checkbook']
+        checkbook = checkbook_obj.browse(cr, uid, [checkbook_id])
         if checkbook:
             vals['account_bank_id'] = checkbook.bank_account_id.id
             vals['type'] = checkbook.type

--- a/l10n_ar_account_create_check/checkbook.py
+++ b/l10n_ar_account_create_check/checkbook.py
@@ -173,6 +173,10 @@ class account_issued_check(models.Model):
         return ret
 
     def create(self, cr, uid, vals, context=None):
+        checkbook = vals.get('checkbook', False)
+        if checkbook:
+            vals['account_bank_id'] = checkbook.bank_account_id.id
+            vals['type'] = checkbook.type
         a = vals.get('check_id', False)
         if a:
             self.pool.get('account.checkbook.check').write(cr, uid, a, {'state': 'done'})

--- a/l10n_ar_account_create_check/wizard/create_checkbook.py
+++ b/l10n_ar_account_create_check/wizard/create_checkbook.py
@@ -35,6 +35,7 @@ class wizard_create_check(osv.osv_memory):
         'end_num': fields.char('End number of check', size=20, required=True),
         'checkbook_num': fields.char('Checkbook number', size=20, required=True),
         'company_id': fields.many2one('res.company', 'Company', required=True),
+        'type': fields.selection([('common', 'Common'), ('postdated', 'Post-dated')], 'Checkbook Type', help="If common, checks only have issued_date. If post-dated they also have payment date"),
     }
 
     _defaults = {
@@ -57,7 +58,7 @@ class wizard_create_check(osv.osv_memory):
             # Creamos los cheques numerados
             checks = []
             for n in range(start_num, end_num + 1):
-                check_vals = {'name': str(n)}
+                check_vals = {'name': str(n), 'type': form.type}
                 checks.append((0, 0, check_vals))
 
             # Creamos la chequera
@@ -65,7 +66,8 @@ class wizard_create_check(osv.osv_memory):
                 'name': form.checkbook_num,
                 'bank_id': form.bank_account_id.bank.id,
                 'bank_account_id': form.bank_account_id.id,
-                'check_ids': checks
+                'check_ids': checks,
+                'type': form.type,
             }
 
             checkbook_id = checkbook_obj.create(cr, uid, checkbook_vals, context)

--- a/l10n_ar_account_create_check/wizard/create_checkbook.py
+++ b/l10n_ar_account_create_check/wizard/create_checkbook.py
@@ -35,7 +35,7 @@ class wizard_create_check(osv.osv_memory):
         'end_num': fields.char('End number of check', size=20, required=True),
         'checkbook_num': fields.char('Checkbook number', size=20, required=True),
         'company_id': fields.many2one('res.company', 'Company', required=True),
-        'type': fields.selection([('common', 'Common'), ('postdated', 'Post-dated')], 'Checkbook Type', help="If common, checks only have issued_date. If post-dated they also have payment date"),
+        'type': fields.selection([('common', 'Common'), ('postdated', 'Post-dated')], 'Checkbook Type', help="If common, checks only have issued_date. If post-dated they also have payment date", required=True),
     }
 
     _defaults = {

--- a/l10n_ar_account_create_check/wizard/create_checkbook_view.xml
+++ b/l10n_ar_account_create_check/wizard/create_checkbook_view.xml
@@ -13,6 +13,7 @@
                         <field name="checkbook_num"/>
                         <field name="start_num"/>
                         <field name="end_num"/>
+                        <field name="type"/>
                     </group>
                     <group col="4">
                         <field name="company_id" groups="base.group_multi_company"/>


### PR DESCRIPTION
Se lleva correctamente el tipo de cheque que figura en la chequera a todos los cheques creados.
Se pasan a readonly campos que no debían ser modificados por el usuario.
Se termina el método de acreditación de cheques diferidos.
Se realizan la conciliación de los asientos que genera un cheque diferido.