### PR TITLE
12.0 some wsfe features

### DIFF
--- a/l10n_ar_wsfe/data/wsfe_data.xml
+++ b/l10n_ar_wsfe/data/wsfe_data.xml
@@ -60,5 +60,53 @@
             <field name="denomination_id" ref="l10n_ar_point_of_sale.denomination_B"/>
         </record>
 
+        <record id="voucher_electronic_credit_A" model="wsfe.voucher_type">
+            <field name="name">Factura de Crédito Electrónica A</field>
+            <field name="code">201</field>
+            <field name="voucher_model">invoice</field>
+            <field name="document_type">out_invoice</field>
+            <field name="denomination_id" ref="l10n_ar_point_of_sale.denomination_A"/>
+        </record>
+
+        <record id="voucher_electronic_debit_note_A" model="wsfe.voucher_type">
+            <field name="name">Nota de Débito Electrónica A</field>
+            <field name="code">202</field>
+            <field name="voucher_model">invoice</field>
+            <field name="document_type">out_debit</field>
+            <field name="denomination_id" ref="l10n_ar_point_of_sale.denomination_A"/>
+        </record>
+
+        <record id="voucher_electronic_credit_note_A" model="wsfe.voucher_type">
+            <field name="name">Nota de Crédito Electrónica A</field>
+            <field name="code">203</field>
+            <field name="voucher_model">invoice</field>
+            <field name="document_type">out_refund</field>
+            <field name="denomination_id" ref="l10n_ar_point_of_sale.denomination_A"/>
+        </record>
+
+        <record id="voucher_electronic_credit_B" model="wsfe.voucher_type">
+            <field name="name">Factura de Crédito Electrónica B</field>
+            <field name="code">206</field>
+            <field name="voucher_model">invoice</field>
+            <field name="document_type">out_invoice</field>
+            <field name="denomination_id" ref="l10n_ar_point_of_sale.denomination_B"/>
+        </record>
+
+        <record id="voucher_electronic_debit_note_B" model="wsfe.voucher_type">
+            <field name="name">Nota de Débito Electrónica B</field>
+            <field name="code">207</field>
+            <field name="voucher_model">invoice</field>
+            <field name="document_type">out_debit</field>
+            <field name="denomination_id" ref="l10n_ar_point_of_sale.denomination_B"/>
+        </record>
+
+        <record id="voucher_electronic_credit_note_B" model="wsfe.voucher_type">
+            <field name="name">Nota de Crédito Electrónica B</field>
+            <field name="code">208</field>
+            <field name="voucher_model">invoice</field>
+            <field name="document_type">out_refund</field>
+            <field name="denomination_id" ref="l10n_ar_point_of_sale.denomination_B"/>
+        </record>
+
     </data>
 </openerp>

--- a/l10n_ar_wsfe/views/account_invoice_view.xml
+++ b/l10n_ar_wsfe/views/account_invoice_view.xml
@@ -88,7 +88,7 @@
                             </field>
                         </group>
                     </page>
-                    <page string="WSFE Requests" attrs="{'invisible': [('wsfe_request_ids', '=', [])]}">
+                    <page string="WSFE Requests">
                         <field name="wsfe_request_ids" readonly="1">
                             <tree string="WSFE Request Details">
                                 <field name="voucher_date"/>


### PR DESCRIPTION
Not possible to check if "Factura de Crédito Electrónica" works under "WSFE Sinchronize Voucher" because not FCE information in the AFIP DB from the CUIT used.

Looks like need to test it in production from some client (MiPYME) that are using FCE